### PR TITLE
refactor(collectors): Use a factory pattern

### DIFF
--- a/lib/collectors/as-arrays.ts
+++ b/lib/collectors/as-arrays.ts
@@ -5,9 +5,18 @@ export type ArraysCollection<V> = V[][]
 /**
  * Convert the grouping to an array of arrays.
  *
- * @param groups The grouping.
  * @returns The resulting array.
  */
-export function asArrays<K, V> (groups: Grouping<K, V>): ArraysCollection<V> {
-  return groups.map((g) => g.items)
+export type ArraysCollector<V> = () => ArraysCollection<V>
+
+/**
+ * Create an ArraysCollector for the given grouping.
+ *
+ * @param groups The grouping.
+ * @returns The created collector.
+ */
+export function asArraysFactory<K, V> (groups: Grouping<K, V>): ArraysCollector<V> {
+  return () => {
+    return groups.map((g) => g.items)
+  }
 }

--- a/lib/collectors/as-entries.ts
+++ b/lib/collectors/as-entries.ts
@@ -15,16 +15,25 @@ export type EntriesCollection<K, V> = Array<Record<string, K | V[]>>
  * - keyName: name of `key` property in resulting objects
  * - itemsName: name of `items` property in resulting objects
  *
- * @param groups The grouping.
  * @param options Collector options.
  * @returns The resulting array.
  */
-export function asEntries<K, V> (groups: Grouping<K, V>, options?: EntriesCollectorOptions): EntriesCollection<K, V> {
-  const keyName = options?.keyName ?? 'key'
-  const itemsName = options?.itemsName ?? 'items'
+export type EntriesCollector<K, V> = (options?: EntriesCollectorOptions) => EntriesCollection<K, V>
 
-  return groups.map((g: GroupingEntry<K, V>) => ({
-    [keyName]: g.key,
-    [itemsName]: g.items
-  }))
+/**
+ * Create an EntriesCollector for the given grouping.
+ *
+ * @param groups The grouping.
+ * @returns The created collector.
+ */
+export function asEntriesFactory<K, V> (groups: Grouping<K, V>): EntriesCollector<K, V> {
+  return (options?: EntriesCollectorOptions) => {
+    const keyName = options?.keyName ?? 'key'
+    const itemsName = options?.itemsName ?? 'items'
+
+    return groups.map((g: GroupingEntry<K, V>) => ({
+      [keyName]: g.key,
+      [itemsName]: g.items
+    }))
+  }
 }

--- a/lib/collectors/as-map.ts
+++ b/lib/collectors/as-map.ts
@@ -5,13 +5,22 @@ export type MapCollection<K, V> = Map<K, V[]>
 /**
  * Convert the grouping to a Map.
  *
- * @param groups The grouping.
- * @returns The resulting map.
+ * @returns The resulting Map.
  */
-export function asMap<K, V> (groups: Grouping<K, V>): MapCollection<K, V> {
-  const map = new Map()
-  for (const group of groups) {
-    map.set(group.key, group.items)
+export type MapCollector<K, V> = () => MapCollection<K, V>
+
+/**
+ * Create a MapCollector for the given grouping.
+ *
+ * @param groups The grouping.
+ * @returns The created collector.
+ */
+export function asMapFactory<K, V> (groups: Grouping<K, V>): MapCollector<K, V> {
+  return () => {
+    const map = new Map()
+    for (const group of groups) {
+      map.set(group.key, group.items)
+    }
+    return map
   }
-  return map
 }

--- a/lib/collectors/as-object.ts
+++ b/lib/collectors/as-object.ts
@@ -5,14 +5,24 @@ export type ObjectCollection<K extends string | number | symbol, V> = Record<K, 
 /**
  * Convert the grouping to an object mapping.
  *
- * @param groups The grouping.
  * @returns The resulting object.
  */
-export function asObject<K extends string | number | symbol, V> (groups: Grouping<K, V>): ObjectCollection<K, V> {
-  // @ts-expect-error
-  const obj: ObjectCollection<K, V> = {}
-  for (const group of groups) {
-    obj[group.key] = group.items
+export type ObjectCollector<K, V> = K extends string | number | symbol ? () => ObjectCollection<K, V> : () => ObjectCollection<string | number | symbol, V>
+
+/**
+ * Create an ObjectCollector for the given grouping.
+ *
+ * @param groups The grouping.
+ * @returns The created collector.
+ */
+export function asObjectFactory<K, V> (groups: Grouping<K, V>): ObjectCollector<K, V> {
+  return () => {
+    const obj: ObjectCollection<string | number | symbol, V> = {}
+    for (const group of groups) {
+      if (typeof group.key === 'string' || typeof group.key === 'number' || typeof group.key === 'symbol') {
+        obj[group.key] = group.items
+      }
+    }
+    return obj
   }
-  return obj
 }

--- a/lib/collectors/as-tuples.ts
+++ b/lib/collectors/as-tuples.ts
@@ -5,9 +5,18 @@ export type TuplesCollection<K, V> = Array<[K, V[]]>
 /**
  * Convert the grouping to an array of tuples.
  *
- * @param groups The grouping.
  * @returns The resulting tuple array.
  */
-export function asTuples<K, V> (groups: Grouping<K, V>): TuplesCollection<K, V> {
-  return groups.map((g) => [g.key, g.items])
+export type TuplesCollector<K, V> = () => TuplesCollection<K, V>
+
+/**
+ * Create a TuplesCollector for the given grouping.
+ *
+ * @param groups The grouping.
+ * @returns The created collector.
+ */
+export function asTuplesFactory<K, V> (groups: Grouping<K, V>): TuplesCollector<K, V> {
+  return () => {
+    return groups.map((g) => [g.key, g.items])
+  }
 }

--- a/lib/collectors/keys.ts
+++ b/lib/collectors/keys.ts
@@ -5,9 +5,18 @@ export type KeysCollection<K> = K[]
 /**
  * Convert the grouping to an array of keys.
  *
- * @param groups The grouping.
  * @returns The resulting array.
  */
-export function keys<K> (groups: Grouping<K, any>): KeysCollection<K> {
-  return groups.map((g) => g.key)
+export type KeysCollector<K> = () => KeysCollection<K>
+
+/**
+ * Create a TuplesCollector for the given grouping.
+ *
+ * @param groups The grouping.
+ * @returns The created collector.
+ */
+export function keysFactory<K, V> (groups: Grouping<K, V>): KeysCollector<K> {
+  return () => {
+    return groups.map((g) => g.key)
+  }
 }

--- a/test/collectors/as-arrays.test.ts
+++ b/test/collectors/as-arrays.test.ts
@@ -1,17 +1,19 @@
 import { expect } from 'chai'
 
-import { asArrays } from '../../lib/collectors/as-arrays'
+import { asArraysFactory } from '../../lib/collectors/as-arrays'
 
 describe('collectors/as-arrays.ts', function () {
   it('returns empty array for empty input', function () {
-    expect(asArrays([])).to.deep.equal([])
+    const collector = asArraysFactory([])
+    expect(collector()).to.deep.equal([])
   })
 
   it('returns array of item arrays', function () {
-    expect(asArrays([
+    const collector = asArraysFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ])).to.deep.equal([
+    ])
+    expect(collector()).to.deep.equal([
       [1, 2, 3],
       [4, 5, 6]
     ])

--- a/test/collectors/as-entries.test.ts
+++ b/test/collectors/as-entries.test.ts
@@ -1,47 +1,52 @@
 import { expect } from 'chai'
 
-import { asEntries } from '../../lib/collectors/as-entries'
+import { asEntriesFactory } from '../../lib/collectors/as-entries'
 
 describe('collectors/as-entries.ts', function () {
   it('returns empty array for empty input', function () {
-    expect(asEntries([])).to.deep.equal([])
+    const collector = asEntriesFactory([])
+    expect(collector()).to.deep.equal([])
   })
 
   it('returns array of entries', function () {
-    expect(asEntries([
+    const collector = asEntriesFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ])).to.deep.equal([
+    ])
+    expect(collector()).to.deep.equal([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
   })
 
   it('ignores empty options object', function () {
-    expect(asEntries([
+    const collector = asEntriesFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ], {})).to.deep.equal([
+    ])
+    expect(collector({})).to.deep.equal([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
   })
 
   it('allows specifying keyName option', function () {
-    expect(asEntries([
+    const collector = asEntriesFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ], { keyName: 'foo' })).to.deep.equal([
+    ])
+    expect(collector({ keyName: 'foo' })).to.deep.equal([
       { foo: 1, items: [1, 2, 3] },
       { foo: 2, items: [4, 5, 6] }
     ])
   })
 
   it('allows specifying itemsName option', function () {
-    expect(asEntries([
+    const collector = asEntriesFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ], { itemsName: 'bar' })).to.deep.equal([
+    ])
+    expect(collector({ itemsName: 'bar' })).to.deep.equal([
       { key: 1, bar: [1, 2, 3] },
       { key: 2, bar: [4, 5, 6] }
     ])

--- a/test/collectors/as-map.test.ts
+++ b/test/collectors/as-map.test.ts
@@ -1,17 +1,19 @@
 import { expect } from 'chai'
 
-import { asMap } from '../../lib/collectors/as-map'
+import { asMapFactory } from '../../lib/collectors/as-map'
 
 describe('collectors/as-map.ts', function () {
   it('returns empty Map for empty input', function () {
-    expect(asMap([])).to.be.a('Map').with.lengthOf(0)
+    const collector = asMapFactory([])
+    expect(collector()).to.be.a('Map').with.lengthOf(0)
   })
 
   it('returns Map between key and array of items', function () {
-    const obj = asMap([
+    const collector = asMapFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
+    const obj = collector()
     expect(obj).to.be.a('Map').with.lengthOf(2)
     expect([...obj.entries()]).to.deep.equal([
       [1, [1, 2, 3]],

--- a/test/collectors/as-object.test.ts
+++ b/test/collectors/as-object.test.ts
@@ -1,17 +1,19 @@
 import { expect } from 'chai'
 
-import { asObject } from '../../lib/collectors/as-object'
+import { asObjectFactory } from '../../lib/collectors/as-object'
 
 describe('collectors/as-object.ts', function () {
   it('returns empty object for empty input', function () {
-    expect(asObject([])).to.deep.equal({})
+    const collector = asObjectFactory([])
+    expect(collector()).to.deep.equal({})
   })
 
   it('returns mapping between key and array of items', function () {
-    expect(asObject([
+    const collector = asObjectFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ])).to.deep.equal({
+    ])
+    expect(collector()).to.deep.equal({
       1: [1, 2, 3],
       2: [4, 5, 6]
     })

--- a/test/collectors/as-tuples.test.ts
+++ b/test/collectors/as-tuples.test.ts
@@ -1,17 +1,19 @@
 import { expect } from 'chai'
 
-import { asTuples } from '../../lib/collectors/as-tuples'
+import { asTuplesFactory } from '../../lib/collectors/as-tuples'
 
 describe('collectors/as-tuples.ts', function () {
   it('returns empty array for empty input', function () {
-    expect(asTuples([])).to.deep.equal([])
+    const collector = asTuplesFactory([])
+    expect(collector()).to.deep.equal([])
   })
 
   it('returns array of [key, items] tuples', function () {
-    expect(asTuples([
+    const collector = asTuplesFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ])).to.deep.equal([
+    ])
+    expect(collector()).to.deep.equal([
       [1, [1, 2, 3]],
       [2, [4, 5, 6]]
     ])

--- a/test/collectors/keys.test.ts
+++ b/test/collectors/keys.test.ts
@@ -1,16 +1,18 @@
 import { expect } from 'chai'
 
-import { keys } from '../../lib/collectors/keys'
+import { keysFactory } from '../../lib/collectors/keys'
 
 describe('collectors/keys.ts', function () {
   it('returns empty array for empty input', function () {
-    expect(keys([])).to.deep.equal([])
+    const collector = keysFactory([])
+    expect(collector()).to.deep.equal([])
   })
 
   it('returns array of keys', function () {
-    expect(keys([
+    const collector = keysFactory([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
-    ])).to.deep.equal([1, 2])
+    ])
+    expect(collector()).to.deep.equal([1, 2])
   })
 })

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es2018",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "strict": true
   },
   "exclude": [


### PR DESCRIPTION
This allows the collectors to specify additional arguments,
without anyone else having to know about them explicitly.