### PR TITLE
feat(index): Re-export important types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ key, primitive or complex, and into whatever structure you desire.
 Example:
 
 ```js
-const group = require('group-items')
+import { group } from 'group-items'
 
 // group names by length
 const items = ['James', 'John', 'Robert', 'Michael', 'William', 'David']
@@ -35,6 +35,10 @@ generated and there are other collectors in addition to `.asObject()`.
 ## Usage
 
 ```js
+// TypeScript:
+import { group } from 'group-items'
+
+// JavaScript:
 const group = require('group-items')
 ```
 
@@ -99,10 +103,12 @@ as you would expect. Maps have the advantage of supporting non-primitive keys.
 `.asObject()`
 
 collects into a JavaScript `Object`. You can find an example for this above.
+Note that due to the nature of JavaScript objects, only values of type
+`string`, `number` or `symbol` will be included in the result.
 
 `.asTuples()`
 
-collects into an array of 2-tuples, i.e. an array of the following form:
+collects into an array of 2-tuples, i.e., an array of the following form:
 
 ```js
 [

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,10 @@
-import { group } from './lib/group'
+// export group function and required types
+export { group, Groupable, Collectable, KeyingFunction } from './lib/group'
 
-export = group
+// export collector results
+export { ArraysCollection } from './lib/collectors/as-arrays'
+export { EntriesCollectorOptions, EntriesCollection } from './lib/collectors/as-entries'
+export { MapCollection } from './lib/collectors/as-map'
+export { ObjectCollection } from './lib/collectors/as-object'
+export { TuplesCollection } from './lib/collectors/as-tuples'
+export { KeysCollection } from './lib/collectors/keys'


### PR DESCRIPTION
Types such as `Groupable` or `Collectable` as well as the collection results could be required inside calling code.
This PR adds exports for them.

This necessitates foregoing a single-item export (CommonJS-style default export with `export = `), hence the `group` function is now also a named export.