### PR TITLE
feat(asEntries): Infer type depending on options presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Options:
 - `keyName`: name of the key property (default: `'key'`)
 - `itemsName`: name of the items property (default: `'items'`)
 
+_Note that due to how TypeScript works, the return type of this method cannot
+be inferred correctly when customizing property names. In those cases, an array
+of `Record` will be returned which you have to cast yourself._
+
 `.asMap()`
 
 collects into a JavaScript

--- a/lib/collectors/as-entries.ts
+++ b/lib/collectors/as-entries.ts
@@ -5,8 +5,15 @@ export interface EntriesCollectorOptions {
   itemsName?: string
 }
 
-// TODO find a way to strongly-type this
-export type EntriesCollection<K, V> = Array<Record<string, K | V[]>>
+export type EntriesCollection<K, V> = Array<{ key: K, items: V[] }>
+
+// This below is the most precise typing I could come up with.
+// It detects whether options are either not supplied at all or match the default options, in which case
+// the standard { key, items } entries are used; in all other cases, the property names cannot be deduced
+// and we have unfortunately to fall back to Record.
+// Note also that empty options objects cannot be detected at all and result in a Record as well.
+//
+// Yes, this is quite insufficient. If you can come up with anything better please contribute!
 
 /**
  * Convert the grouping to an array of entry objects.
@@ -18,7 +25,10 @@ export type EntriesCollection<K, V> = Array<Record<string, K | V[]>>
  * @param options Collector options.
  * @returns The resulting array.
  */
-export type EntriesCollector<K, V> = (options?: EntriesCollectorOptions) => EntriesCollection<K, V>
+export type EntriesCollector<K, V> = <Opt extends { keyName: 'key', itemsName: 'items' } | EntriesCollectorOptions | undefined | null = undefined> (options?: Opt) =>
+Opt extends undefined | null | { keyName: 'key', itemsName: 'items' } | { itemsName: 'items' } | { keyName: 'key' }
+  ? EntriesCollection<K, V>
+  : Array<Record<string, K | V[]>>
 
 /**
  * Create an EntriesCollector for the given grouping.
@@ -27,13 +37,13 @@ export type EntriesCollector<K, V> = (options?: EntriesCollectorOptions) => Entr
  * @returns The created collector.
  */
 export function asEntriesFactory<K, V> (groups: Grouping<K, V>): EntriesCollector<K, V> {
-  return (options?: EntriesCollectorOptions) => {
-    const keyName = options?.keyName ?? 'key'
-    const itemsName = options?.itemsName ?? 'items'
+  return ((options) => {
+    const keyName: string = options?.keyName ?? 'key'
+    const itemsName: string = options?.itemsName ?? 'items'
 
     return groups.map((g: GroupingEntry<K, V>) => ({
       [keyName]: g.key,
       [itemsName]: g.items
     }))
-  }
+  }) as EntriesCollector<K, V>
 }

--- a/test/collectors/as-entries.test.ts
+++ b/test/collectors/as-entries.test.ts
@@ -51,4 +51,15 @@ describe('collectors/as-entries.ts', function () {
       { key: 2, bar: [4, 5, 6] }
     ])
   })
+
+  it('allows specifying both keyName and itemsName options', function () {
+    const collector = asEntriesFactory([
+      { key: 1, items: [1, 2, 3] },
+      { key: 2, items: [4, 5, 6] }
+    ])
+    expect(collector({ keyName: 'foo', itemsName: 'bar' })).to.deep.equal([
+      { foo: 1, bar: [1, 2, 3] },
+      { foo: 2, bar: [4, 5, 6] }
+    ])
+  })
 })


### PR DESCRIPTION
So far, asEntries always returned an array of records.
Now it can at least detect the case where no options have been supplied, or default options have been used, and will return the proper object type. In all other cases type inference is still lacking.