### PR TITLE
chore: Build on 'prepack' instead of 'prepare'

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit && eslint --fix --ignore-path .gitignore .",
     "coverage": "c8 --all --src=src --reporter=text --reporter=lcov npm test",
-    "prepare": "npm run build"
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
'prepare' builds on every 'npm install', as well as on 'npm publish'.
'prepack' will only build when actually packing or publishing.