### PR TITLE
chore: migrate to map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "group-items",
       "version": "2.2.0",
       "license": "MIT",
-      "dependencies": {
-        "deep-eql": "^4.0.0"
-      },
       "devDependencies": {
         "@meyfa/eslint-config": "2.1.1",
         "@types/chai": "4.3.3",
@@ -1104,17 +1101,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.0.tgz",
-      "integrity": "sha512-4YM7QHOMBoVWqGPnp3OPPK7+WCIhUR2OTpahlNQFiyTH3QEeiu9MtBiTAJBkfny4PNhpFbV/jm3lv0iCfb40MA==",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3464,6 +3450,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4450,14 +4437,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.0.tgz",
-      "integrity": "sha512-4YM7QHOMBoVWqGPnp3OPPK7+WCIhUR2OTpahlNQFiyTH3QEeiu9MtBiTAJBkfny4PNhpFbV/jm3lv0iCfb40MA==",
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "deep-is": {
       "version": "0.1.4",
@@ -6133,7 +6112,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "mocha": "10.1.0",
     "ts-node": "10.9.1",
     "typescript": "4.8.4"
-  },
-  "dependencies": {
-    "deep-eql": "^4.0.0"
   }
 }

--- a/src/collectors/as-arrays.ts
+++ b/src/collectors/as-arrays.ts
@@ -17,6 +17,8 @@ export type ArraysCollector<V> = () => ArraysCollection<V>
  */
 export function asArraysFactory<K, V> (groups: Grouping<K, V>): ArraysCollector<V> {
   return () => {
-    return groups.map((g) => g.items)
+    const result: V[][] = []
+    groups.forEach((g) => result.push(g.items))
+    return result
   }
 }

--- a/src/collectors/as-entries.ts
+++ b/src/collectors/as-entries.ts
@@ -1,5 +1,4 @@
-import { Grouping, GroupingEntry } from '../types.js'
-
+import { Grouping } from '../types.js'
 export interface EntriesCollectorOptions {
   keyName?: string
   itemsName?: string
@@ -41,9 +40,15 @@ export function asEntriesFactory<K, V> (groups: Grouping<K, V>): EntriesCollecto
     const keyName: string = options?.keyName ?? 'key'
     const itemsName: string = options?.itemsName ?? 'items'
 
-    return groups.map((g: GroupingEntry<K, V>) => ({
+    const result: Array<{
+      [x: string]: K | V[]
+    }> = []
+
+    groups.forEach((g) => result.push({
       [keyName]: g.key,
       [itemsName]: g.items
     }))
+
+    return result
   }) as EntriesCollector<K, V>
 }

--- a/src/collectors/as-map.ts
+++ b/src/collectors/as-map.ts
@@ -19,7 +19,7 @@ export function asMapFactory<K, V> (groups: Grouping<K, V>): MapCollector<K, V> 
   return () => {
     const map = new Map()
     for (const group of groups) {
-      map.set(group.key, group.items)
+      map.set(group[1].key, group[1].items)
     }
     return map
   }

--- a/src/collectors/as-object.ts
+++ b/src/collectors/as-object.ts
@@ -31,8 +31,8 @@ export function asObjectFactory<K, V> (groups: Grouping<K, V>): ObjectCollector<
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const obj = {} as ObjectCollection<Extract<K, keyof any>, V>
     for (const group of groups) {
-      if (isObjectAssignable(group.key)) {
-        obj[group.key] = group.items
+      if (isObjectAssignable(group[1].key)) {
+        obj[group[1].key] = group[1].items
       }
     }
     return obj

--- a/src/collectors/as-tuples.ts
+++ b/src/collectors/as-tuples.ts
@@ -17,6 +17,8 @@ export type TuplesCollector<K, V> = () => TuplesCollection<K, V>
  */
 export function asTuplesFactory<K, V> (groups: Grouping<K, V>): TuplesCollector<K, V> {
   return () => {
-    return groups.map((g) => [g.key, g.items])
+    const result: Array<[key: K, items: V[]]> = []
+    groups.forEach((g) => result.push([g.key, g.items]))
+    return result
   }
 }

--- a/src/collectors/keys.ts
+++ b/src/collectors/keys.ts
@@ -17,6 +17,6 @@ export type KeysCollector<K> = () => KeysCollection<K>
  */
 export function keysFactory<K, V> (groups: Grouping<K, V>): KeysCollector<K> {
   return () => {
-    return groups.map((g) => g.key)
+    return Array.from(groups.keys())
   }
 }

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,5 +1,3 @@
-import deepEql from 'deep-eql'
-
 import { Grouping, GroupingEntry } from './types.js'
 import { findOrCreate } from './util/find-or-create.js'
 import { ArraysCollector, asArraysFactory } from './collectors/as-arrays.js'
@@ -53,15 +51,14 @@ export interface Collectable<K, V> {
  * @returns Array of groups.
  */
 function createGrouping<K, V> (items: Iterable<V>, keyFn: KeyingFunction<K, V>): Grouping<K, V> {
-  const groups: Grouping<K, V> = []
+  const groups: Grouping<K, V> = new Map()
   let idx = 0
   for (const item of items) {
     const itemKey = keyFn(item, idx)
     idx++
 
-    const predicate = (g: GroupingEntry<K, V>): boolean => deepEql(g.key, itemKey)
     const construct = (): GroupingEntry<K, V> => ({ key: itemKey, items: [] })
-    findOrCreate(groups, predicate, construct).items.push(item)
+    findOrCreate(groups, itemKey, construct).items.push(item)
   }
   return groups
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,4 @@ export interface GroupingEntry<K, V> {
   items: V[]
 }
 
-export type Grouping<K, V> = Array<GroupingEntry<K, V>>
+export type Grouping<K, V> = Map<K, GroupingEntry<K, V>>

--- a/src/util/find-or-create.ts
+++ b/src/util/find-or-create.ts
@@ -7,17 +7,18 @@
  *
  * THIS MODIFIES THE ARRAY.
  *
- * @param arr The array to search.
+ * @param arr The map to search.
  * @param predicate The search condition.
  * @param construct The creator function.
  * @returns The entry that was found, or created.
  */
-export function findOrCreate<T> (arr: T[], predicate: (t: T) => boolean, construct: () => T): T {
-  const index = arr.findIndex((entry) => predicate(entry))
-  if (index >= 0) {
-    return arr[index]
+export function findOrCreate<K, V> (arr: Map<K, V>, predicate: K, construct: () => V): V {
+  const value = arr.has(predicate)
+  if (value) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return arr.get(predicate)!
   }
   const newEntry = construct()
-  arr.push(newEntry)
+  arr.set(predicate, newEntry)
   return newEntry
 }

--- a/test/collectors/as-arrays.test.ts
+++ b/test/collectors/as-arrays.test.ts
@@ -4,15 +4,14 @@ import { asArraysFactory } from '../../src/collectors/as-arrays.js'
 
 describe('collectors/as-arrays.ts', function () {
   it('returns empty array for empty input', function () {
-    const collector = asArraysFactory([])
+    const collector = asArraysFactory(new Map())
     expect(collector()).to.deep.equal([])
   })
 
   it('returns array of item arrays', function () {
-    const collector = asArraysFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asArraysFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] }))
     expect(collector()).to.deep.equal([
       [1, 2, 3],
       [4, 5, 6]

--- a/test/collectors/as-entries.test.ts
+++ b/test/collectors/as-entries.test.ts
@@ -4,15 +4,14 @@ import { asEntriesFactory } from '../../src/collectors/as-entries.js'
 
 describe('collectors/as-entries.ts', function () {
   it('returns empty array for empty input', function () {
-    const collector = asEntriesFactory([])
+    const collector = asEntriesFactory(new Map())
     expect(collector()).to.deep.equal([])
   })
 
   it('returns array of entries', function () {
-    const collector = asEntriesFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asEntriesFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] }))
     expect(collector()).to.deep.equal([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
@@ -20,10 +19,9 @@ describe('collectors/as-entries.ts', function () {
   })
 
   it('ignores empty options object', function () {
-    const collector = asEntriesFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asEntriesFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] }))
     expect(collector({})).to.deep.equal([
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
@@ -31,10 +29,9 @@ describe('collectors/as-entries.ts', function () {
   })
 
   it('allows specifying keyName option', function () {
-    const collector = asEntriesFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asEntriesFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] }))
     expect(collector({ keyName: 'foo' })).to.deep.equal([
       { foo: 1, items: [1, 2, 3] },
       { foo: 2, items: [4, 5, 6] }
@@ -42,10 +39,9 @@ describe('collectors/as-entries.ts', function () {
   })
 
   it('allows specifying itemsName option', function () {
-    const collector = asEntriesFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asEntriesFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] }))
     expect(collector({ itemsName: 'bar' })).to.deep.equal([
       { key: 1, bar: [1, 2, 3] },
       { key: 2, bar: [4, 5, 6] }
@@ -53,10 +49,10 @@ describe('collectors/as-entries.ts', function () {
   })
 
   it('allows specifying both keyName and itemsName options', function () {
-    const collector = asEntriesFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asEntriesFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] })
+    )
     expect(collector({ keyName: 'foo', itemsName: 'bar' })).to.deep.equal([
       { foo: 1, bar: [1, 2, 3] },
       { foo: 2, bar: [4, 5, 6] }

--- a/test/collectors/as-map.test.ts
+++ b/test/collectors/as-map.test.ts
@@ -4,15 +4,15 @@ import { asMapFactory } from '../../src/collectors/as-map.js'
 
 describe('collectors/as-map.ts', function () {
   it('returns empty Map for empty input', function () {
-    const collector = asMapFactory([])
+    const collector = asMapFactory(new Map())
     expect(collector()).to.be.a('Map').with.lengthOf(0)
   })
 
   it('returns Map between key and array of items', function () {
-    const collector = asMapFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asMapFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] })
+    )
     const obj = collector()
     expect(obj).to.be.a('Map').with.lengthOf(2)
     expect(Array.from(obj.entries())).to.deep.equal([

--- a/test/collectors/as-object.test.ts
+++ b/test/collectors/as-object.test.ts
@@ -5,15 +5,15 @@ import { Grouping } from '../../src/types.js'
 
 describe('collectors/as-object.ts', function () {
   it('returns empty object for empty input', function () {
-    const collector = asObjectFactory([])
+    const collector = asObjectFactory(new Map())
     expect(collector()).to.deep.equal({})
   })
 
   it('returns mapping between key and array of items', function () {
-    const collector = asObjectFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asObjectFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] })
+    )
     expect(collector()).to.deep.equal({
       1: [1, 2, 3],
       2: [4, 5, 6]
@@ -21,10 +21,10 @@ describe('collectors/as-object.ts', function () {
   })
 
   it('returns mapping for key typed as string union', function () {
-    const groups: Grouping<'foo' | 'bar', number> = [
-      { key: 'foo', items: [1, 2, 3] },
-      { key: 'bar', items: [4, 5, 6] }
-    ]
+    const groups: Grouping<'foo' | 'bar', number> = new Map()
+      .set('foo', { key: 'foo', items: [1, 2, 3] })
+      .set('bar', { key: 'bar', items: [4, 5, 6] })
+
     const collector = asObjectFactory(groups)
     // type the result explicitly to assert its correctness
     const result: Record<'foo' | 'bar', number[]> = collector()
@@ -35,11 +35,10 @@ describe('collectors/as-object.ts', function () {
   })
 
   it('excludes keys that cannot be object properties due to their type', function () {
-    const groups: Grouping<string | boolean | number, number> = [
-      { key: 'foo', items: [1, 2, 3] },
-      { key: false, items: [4, 5, 6] },
-      { key: 42, items: [8, 9, 0] }
-    ]
+    const groups: Grouping<string | boolean | number, number> = new Map()
+      .set('foo', { key: 'foo', items: [1, 2, 3] })
+      .set(false, { key: false, items: [4, 5, 6] })
+      .set(42, { key: 42, items: [8, 9, 0] })
     const collector = asObjectFactory(groups)
     // type the result explicitly to assert its correctness
     const result: Record<string | number, number[]> = collector()

--- a/test/collectors/as-tuples.test.ts
+++ b/test/collectors/as-tuples.test.ts
@@ -4,15 +4,15 @@ import { asTuplesFactory } from '../../src/collectors/as-tuples.js'
 
 describe('collectors/as-tuples.ts', function () {
   it('returns empty array for empty input', function () {
-    const collector = asTuplesFactory([])
+    const collector = asTuplesFactory(new Map())
     expect(collector()).to.deep.equal([])
   })
 
   it('returns array of [key, items] tuples', function () {
-    const collector = asTuplesFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = asTuplesFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] })
+    )
     expect(collector()).to.deep.equal([
       [1, [1, 2, 3]],
       [2, [4, 5, 6]]

--- a/test/collectors/keys.test.ts
+++ b/test/collectors/keys.test.ts
@@ -4,15 +4,14 @@ import { keysFactory } from '../../src/collectors/keys.js'
 
 describe('collectors/keys.ts', function () {
   it('returns empty array for empty input', function () {
-    const collector = keysFactory([])
+    const collector = keysFactory(new Map())
     expect(collector()).to.deep.equal([])
   })
 
   it('returns array of keys', function () {
-    const collector = keysFactory([
-      { key: 1, items: [1, 2, 3] },
-      { key: 2, items: [4, 5, 6] }
-    ])
+    const collector = keysFactory(new Map()
+      .set(1, { key: 1, items: [1, 2, 3] })
+      .set(2, { key: 2, items: [4, 5, 6] }))
     expect(collector()).to.deep.equal([1, 2])
   })
 })

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -52,7 +52,7 @@ describe('group.ts', function () {
     ])
   })
 
-  it('correctly groups objects by identity', function () {
+  it.only('correctly groups objects by identity', function () {
     const obj0 = { a: 1 }
     const obj1 = { a: 1 }
     const obj2 = { a: 2 }

--- a/test/util/find-or-create.test.ts
+++ b/test/util/find-or-create.test.ts
@@ -2,22 +2,30 @@ import { expect } from 'chai'
 
 import { findOrCreate } from '../../src/util/find-or-create.js'
 
+const generateMap = (): Map<number, number> => new Map<number, number>()
+  .set(1, 1)
+  .set(2, 2)
+  .set(3, 3)
+  .set(4, 4)
+  .set(5, 5)
+  .set(6, 6)
+
 describe('util/find-or-create.ts', function () {
   describe('match', function () {
     it('returns first match', function () {
-      const arr = [1, 2, 3, 4, 5, 6]
-      expect(findOrCreate(arr, (i) => i % 2 === 0, () => 42)).to.equal(2)
+      const arr = generateMap()
+      expect(findOrCreate(arr, 2, () => 42)).to.equal(2)
     })
 
     it('leaves array intact on match', function () {
-      const arr = [1, 2, 3, 4, 5, 6]
-      findOrCreate(arr, (i) => i % 2 === 0, () => 42)
-      expect(arr).to.deep.equal([1, 2, 3, 4, 5, 6])
+      const arr = generateMap()
+      findOrCreate(arr, 2, () => 42)
+      expect(arr).to.deep.equal(generateMap())
     })
 
     it('does not call construct on match', function (done) {
-      const arr = [1, 2, 3, 4, 5, 6]
-      findOrCreate(arr, (i) => i % 2 === 0, () => {
+      const arr = generateMap()
+      findOrCreate(arr, 2, () => {
         done(new Error('called'))
         return 0
       })
@@ -25,34 +33,45 @@ describe('util/find-or-create.ts', function () {
     })
 
     it('matches even if match is falsy', function () {
-      const arr = [1, 2, 0, 3]
-      expect(findOrCreate(arr, (i) => i === 0, () => 42)).to.equal(0)
-      expect(arr).to.deep.equal([1, 2, 0, 3])
+      const arr = new Map()
+        .set(1, 1)
+        .set(2, 2)
+        .set(0, 0)
+        .set(3, 3)
+      expect(findOrCreate(arr, 0, () => 42)).to.equal(0)
+      expect(arr).to.deep.equal(new Map()
+        .set(1, 1)
+        .set(2, 2)
+        .set(0, 0)
+        .set(3, 3))
     })
 
     it('matches even if match is literal undefined', function () {
-      const arr = [undefined]
-      expect(findOrCreate(arr, () => true, () => 42)).to.be.undefined
-      expect(arr).to.deep.equal([undefined])
+      const arr = new Map()
+        .set(42, undefined)
+      expect(findOrCreate(arr, 42, () => 42)).to.be.undefined
+      expect(arr).to.deep.equal(new Map().set(42, undefined))
     })
   })
 
   describe('no match', function () {
     it('returns constructed item if none match', function () {
-      const arr = [1, 2, 3, 4, 5, 6]
-      expect(findOrCreate(arr, () => false, () => 42)).to.equal(42)
+      const arr = generateMap()
+      expect(findOrCreate(arr, undefined, () => 42)).to.equal(42)
     })
 
     it('appends constructed item to array', function () {
-      const arr = [1, 2, 3, 4, 5, 6]
-      findOrCreate(arr, () => false, () => 42)
-      expect(arr).to.deep.equal([1, 2, 3, 4, 5, 6, 42])
+      const arr = generateMap()
+      findOrCreate(arr, 42, () => 42)
+      expect(arr).to.deep.equal(generateMap()
+        .set(42, 42))
     })
 
     it('always constructs if array is empty', function () {
-      const arr: number[] = []
-      expect(findOrCreate(arr, () => true, () => 42)).to.equal(42)
-      expect(arr).to.deep.equal([42])
+      const arr = new Map()
+
+      expect(findOrCreate(arr, undefined, () => 42)).to.equal(42)
+      expect(arr).to.deep.equal(new Map().set(undefined, 42))
     })
   })
 })


### PR DESCRIPTION
I got almost everything working but has to remove some small functionality like the deep equal.

The problem is to use an array to store the keys, for each record you search in the array, if you have 1kk records and 100k diferents keys you loop in 100k array 1kk times.

Using a map is so much efficient and allows multiples keys types too, but it's twice the time as lodash groupBy because of the implement of the collectors, you have to loop one time the original array to store in the map with the standard format and a second loop to output in the collector format.

Only 1 test fails because the remove of deep equal, if this is one of your main requires you can cancel this PR without problem, quite enjoy the time I spent 😄 .

Fixes #95