### PR TITLE
chore: Replace chai with native 'assert' module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,9 @@
       },
       "devDependencies": {
         "@meyfa/eslint-config": "3.0.0",
-        "@types/chai": "4.3.4",
         "@types/mocha": "10.0.1",
+        "@types/node": "18.13.0",
         "c8": "7.12.0",
-        "chai": "4.3.7",
         "eslint": "8.34.0",
         "eslint-plugin-jsdoc": "39.3.6",
         "mocha": "10.2.0",
@@ -234,12 +233,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -265,11 +258,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
-      "dev": true,
-      "peer": true
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -792,15 +784,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -913,24 +896,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -945,15 +910,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1905,15 +1861,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -2553,15 +2500,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.0"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2935,15 +2873,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/picomatch": {
@@ -3873,12 +3802,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -3904,11 +3827,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
-      "dev": true,
-      "peer": true
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -4223,12 +4145,6 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4317,21 +4233,6 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
-    "chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4341,12 +4242,6 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -5058,12 +4953,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true
-    },
     "get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -5511,15 +5400,6 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
-    "loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.0"
-      }
-    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5796,12 +5676,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "picomatch": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,9 @@
   },
   "devDependencies": {
     "@meyfa/eslint-config": "3.0.0",
-    "@types/chai": "4.3.4",
     "@types/mocha": "10.0.1",
+    "@types/node": "18.13.0",
     "c8": "7.12.0",
-    "chai": "4.3.7",
     "eslint": "8.34.0",
     "eslint-plugin-jsdoc": "39.3.6",
     "mocha": "10.2.0",

--- a/test/collectors/as-arrays.test.ts
+++ b/test/collectors/as-arrays.test.ts
@@ -1,11 +1,10 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { asArraysFactory } from '../../src/collectors/as-arrays.js'
 
 describe('collectors/as-arrays.ts', function () {
   it('returns empty array for empty input', function () {
     const collector = asArraysFactory([])
-    expect(collector()).to.deep.equal([])
+    assert.deepStrictEqual(collector(), [])
   })
 
   it('returns array of item arrays', function () {
@@ -13,7 +12,7 @@ describe('collectors/as-arrays.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector()).to.deep.equal([
+    assert.deepStrictEqual(collector(), [
       [1, 2, 3],
       [4, 5, 6]
     ])

--- a/test/collectors/as-entries.test.ts
+++ b/test/collectors/as-entries.test.ts
@@ -1,11 +1,10 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { asEntriesFactory } from '../../src/collectors/as-entries.js'
 
 describe('collectors/as-entries.ts', function () {
   it('returns empty array for empty input', function () {
     const collector = asEntriesFactory([])
-    expect(collector()).to.deep.equal([])
+    assert.deepStrictEqual(collector(), [])
   })
 
   it('returns array of entries', function () {
@@ -13,7 +12,7 @@ describe('collectors/as-entries.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector()).to.deep.equal([
+    assert.deepStrictEqual(collector(), [
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
@@ -24,7 +23,7 @@ describe('collectors/as-entries.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector({})).to.deep.equal([
+    assert.deepStrictEqual(collector({}), [
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
@@ -35,7 +34,7 @@ describe('collectors/as-entries.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector({ keyName: 'foo' })).to.deep.equal([
+    assert.deepStrictEqual(collector({ keyName: 'foo' }), [
       { foo: 1, items: [1, 2, 3] },
       { foo: 2, items: [4, 5, 6] }
     ])
@@ -46,7 +45,7 @@ describe('collectors/as-entries.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector({ itemsName: 'bar' })).to.deep.equal([
+    assert.deepStrictEqual(collector({ itemsName: 'bar' }), [
       { key: 1, bar: [1, 2, 3] },
       { key: 2, bar: [4, 5, 6] }
     ])
@@ -57,7 +56,7 @@ describe('collectors/as-entries.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector({ keyName: 'foo', itemsName: 'bar' })).to.deep.equal([
+    assert.deepStrictEqual(collector({ keyName: 'foo', itemsName: 'bar' }), [
       { foo: 1, bar: [1, 2, 3] },
       { foo: 2, bar: [4, 5, 6] }
     ])

--- a/test/collectors/as-map.test.ts
+++ b/test/collectors/as-map.test.ts
@@ -1,11 +1,11 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { asMapFactory } from '../../src/collectors/as-map.js'
 
 describe('collectors/as-map.ts', function () {
   it('returns empty Map for empty input', function () {
     const collector = asMapFactory([])
-    expect(collector()).to.be.a('Map').with.lengthOf(0)
+    assert.ok(collector() instanceof Map)
+    assert.strictEqual(collector().size, 0)
   })
 
   it('returns Map between key and array of items', function () {
@@ -14,8 +14,9 @@ describe('collectors/as-map.ts', function () {
       { key: 2, items: [4, 5, 6] }
     ])
     const obj = collector()
-    expect(obj).to.be.a('Map').with.lengthOf(2)
-    expect(Array.from(obj.entries())).to.deep.equal([
+    assert.ok(obj instanceof Map)
+    assert.strictEqual(obj.size, 2)
+    assert.deepStrictEqual(Array.from(obj.entries()), [
       [1, [1, 2, 3]],
       [2, [4, 5, 6]]
     ])

--- a/test/collectors/as-object.test.ts
+++ b/test/collectors/as-object.test.ts
@@ -1,12 +1,11 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { asObjectFactory } from '../../src/collectors/as-object.js'
 import { Grouping } from '../../src/types.js'
 
 describe('collectors/as-object.ts', function () {
   it('returns empty object for empty input', function () {
     const collector = asObjectFactory([])
-    expect(collector()).to.deep.equal({})
+    assert.deepStrictEqual(collector(), {})
   })
 
   it('returns mapping between key and array of items', function () {
@@ -14,7 +13,7 @@ describe('collectors/as-object.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector()).to.deep.equal({
+    assert.deepStrictEqual(collector(), {
       1: [1, 2, 3],
       2: [4, 5, 6]
     })
@@ -28,7 +27,7 @@ describe('collectors/as-object.ts', function () {
     const collector = asObjectFactory(groups)
     // type the result explicitly to assert its correctness
     const result: Record<'foo' | 'bar', number[]> = collector()
-    expect(result).to.deep.equal({
+    assert.deepStrictEqual(result, {
       foo: [1, 2, 3],
       bar: [4, 5, 6]
     })
@@ -43,7 +42,7 @@ describe('collectors/as-object.ts', function () {
     const collector = asObjectFactory(groups)
     // type the result explicitly to assert its correctness
     const result: Record<string | number, number[]> = collector()
-    expect(result).to.deep.equal({
+    assert.deepStrictEqual(result, {
       foo: [1, 2, 3],
       42: [8, 9, 0]
     })

--- a/test/collectors/as-tuples.test.ts
+++ b/test/collectors/as-tuples.test.ts
@@ -1,11 +1,10 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { asTuplesFactory } from '../../src/collectors/as-tuples.js'
 
 describe('collectors/as-tuples.ts', function () {
   it('returns empty array for empty input', function () {
     const collector = asTuplesFactory([])
-    expect(collector()).to.deep.equal([])
+    assert.deepStrictEqual(collector(), [])
   })
 
   it('returns array of [key, items] tuples', function () {
@@ -13,7 +12,7 @@ describe('collectors/as-tuples.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector()).to.deep.equal([
+    assert.deepStrictEqual(collector(), [
       [1, [1, 2, 3]],
       [2, [4, 5, 6]]
     ])

--- a/test/collectors/keys.test.ts
+++ b/test/collectors/keys.test.ts
@@ -1,11 +1,10 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { keysFactory } from '../../src/collectors/keys.js'
 
 describe('collectors/keys.ts', function () {
   it('returns empty array for empty input', function () {
     const collector = keysFactory([])
-    expect(collector()).to.deep.equal([])
+    assert.deepStrictEqual(collector(), [])
   })
 
   it('returns array of keys', function () {
@@ -13,6 +12,6 @@ describe('collectors/keys.ts', function () {
       { key: 1, items: [1, 2, 3] },
       { key: 2, items: [4, 5, 6] }
     ])
-    expect(collector()).to.deep.equal([1, 2])
+    assert.deepStrictEqual(collector(), [1, 2])
   })
 })

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -1,28 +1,29 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { group } from '../src/group.js'
 
 describe('group.ts', function () {
   it("has function property 'by'", function () {
-    expect(group([])).to.have.property('by').that.is.a('function')
+    assert.strictEqual(typeof group([]).by, 'function')
   })
 
   it('does not create groups for empty input', function () {
-    expect(group([]).by((a) => a).asEntries()).to.be.an('array').with.lengthOf(0)
+    const result = group([]).by((a) => a).asEntries()
+    assert.ok(Array.isArray(result))
+    assert.strictEqual(result.length, 0)
   })
 
   it('correctly groups primitives by index % 2', function () {
-    expect(group([0, 1, 2, 3, 4, 5]).by((v, idx) => {
-      expect(v).to.equal(idx)
+    assert.deepStrictEqual(group([0, 1, 2, 3, 4, 5]).by((v, idx) => {
+      assert.strictEqual(v, idx)
       return idx % 2
-    }).asEntries()).to.deep.equal([
+    }).asEntries(), [
       { key: 0, items: [0, 2, 4] },
       { key: 1, items: [1, 3, 5] }
     ])
   })
 
   it('correctly groups primitives with identity', function () {
-    expect(group([1, 2, 3]).by((i) => i).asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group([1, 2, 3]).by((i) => i).asEntries(), [
       { key: 1, items: [1] },
       { key: 2, items: [2] },
       { key: 3, items: [3] }
@@ -30,14 +31,14 @@ describe('group.ts', function () {
   })
 
   it('correctly groups primitives with simple keying', function () {
-    expect(group([0, 1, 2, 3, 4]).by((i) => i % 2).asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group([0, 1, 2, 3, 4]).by((i) => i % 2).asEntries(), [
       { key: 0, items: [0, 2, 4] },
       { key: 1, items: [1, 3] }
     ])
   })
 
   it('correctly groups strings by length property', function () {
-    expect(group(['a', 'b', 'aaa', 'bbbb', 'cccc']).by('length').asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group(['a', 'b', 'aaa', 'bbbb', 'cccc']).by('length').asEntries(), [
       { key: 1, items: ['a', 'b'] },
       { key: 3, items: ['aaa'] },
       { key: 4, items: ['bbbb', 'cccc'] }
@@ -45,7 +46,7 @@ describe('group.ts', function () {
   })
 
   it('correctly groups arrays by identity', function () {
-    expect(group([[1, 2], [1, 2], [], [5]]).by((i) => i).asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group([[1, 2], [1, 2], [], [5]]).by((i) => i).asEntries(), [
       { key: [1, 2], items: [[1, 2], [1, 2]] },
       { key: [], items: [[]] },
       { key: [5], items: [[5]] }
@@ -59,20 +60,21 @@ describe('group.ts', function () {
     const obj3 = {}
     const result = group([obj0, obj1, obj2, obj3]).by((o) => o).asEntries()
     // expect 3 groups
-    expect(result).to.be.an('array').with.lengthOf(3)
+    assert.ok(Array.isArray(result))
+    assert.strictEqual(result.length, 3)
     // first group
-    expect(result[0].key).to.deep.equal({ a: 1 })
-    expect(result[0].items).to.have.lengthOf(2)
-    expect((result[0].items as any[])[0]).to.equal(obj0)
-    expect((result[0].items as any[])[1]).to.equal(obj1)
+    assert.deepStrictEqual(result[0].key, { a: 1 })
+    assert.strictEqual(result[0].items.length, 2)
+    assert.strictEqual(result[0].items[0], obj0)
+    assert.strictEqual(result[0].items[1], obj1)
     // second group
-    expect(result[1].key).to.deep.equal({ a: 2 })
-    expect(result[1].items).to.have.lengthOf(1)
-    expect((result[1].items as any[])[0]).to.equal(obj2)
+    assert.deepStrictEqual(result[1].key, { a: 2 })
+    assert.strictEqual(result[1].items.length, 1)
+    assert.strictEqual(result[1].items[0], obj2)
     // third group
-    expect(result[2].key).to.deep.equal({})
-    expect(result[2].items).to.have.lengthOf(1)
-    expect((result[2].items as any[])[0]).to.equal(obj3)
+    assert.deepStrictEqual(result[2].key, {})
+    assert.strictEqual(result[2].items.length, 1)
+    assert.strictEqual(result[2].items[0], obj3)
   })
 
   it('correctly groups objects by some property', function () {
@@ -81,27 +83,28 @@ describe('group.ts', function () {
     const obj2 = { a: 2, b: 2 }
     const result = group([obj0, obj1, obj2]).by('a').asEntries()
     // expect 2 groups
-    expect(result).to.be.an('array').with.lengthOf(2)
+    assert.ok(Array.isArray(result))
+    assert.strictEqual(result.length, 2)
     // first group
-    expect(result[0].key).to.equal(1)
-    expect(result[0].items).to.have.lengthOf(2)
-    expect(result[0].items[0]).to.equal(obj0)
-    expect(result[0].items[1]).to.equal(obj1)
+    assert.strictEqual(result[0].key, 1)
+    assert.strictEqual(result[0].items.length, 2)
+    assert.strictEqual(result[0].items[0], obj0)
+    assert.strictEqual(result[0].items[1], obj1)
     // second group
-    expect(result[1].key).to.equal(2)
-    expect(result[1].items).to.have.lengthOf(1)
-    expect(result[1].items[0]).to.equal(obj2)
+    assert.strictEqual(result[1].key, 2)
+    assert.strictEqual(result[1].items.length, 1)
+    assert.strictEqual(result[1].items[0], obj2)
   })
 
   it('supports string as input', function () {
-    expect(group('abcdefg').by((c) => c.charCodeAt(0) % 2).asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group('abcdefg').by((c) => c.charCodeAt(0) % 2).asEntries(), [
       { key: 1, items: ['a', 'c', 'e', 'g'] },
       { key: 0, items: ['b', 'd', 'f'] }
     ])
   })
 
   it('supports Set as input', function () {
-    expect(group(new Set([0, 1, 2, 3, 4])).by((i) => i % 2).asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group(new Set([0, 1, 2, 3, 4])).by((i) => i % 2).asEntries(), [
       { key: 0, items: [0, 2, 4] },
       { key: 1, items: [1, 3] }
     ])
@@ -109,7 +112,7 @@ describe('group.ts', function () {
 
   it('supports Map as input', function () {
     const map = new Map([[1, 'a'], [2, 'b'], [3, 'a']])
-    expect(group(map).by((e) => e[1]).asEntries()).to.deep.equal([
+    assert.deepStrictEqual(group(map).by((e) => e[1]).asEntries(), [
       { key: 'a', items: [[1, 'a'], [3, 'a']] },
       { key: 'b', items: [[2, 'b']] }
     ])

--- a/test/util/find-or-create.test.ts
+++ b/test/util/find-or-create.test.ts
@@ -1,18 +1,17 @@
-import { expect } from 'chai'
-
+import assert from 'assert'
 import { findOrCreate } from '../../src/util/find-or-create.js'
 
 describe('util/find-or-create.ts', function () {
   describe('match', function () {
     it('returns first match', function () {
       const arr = [1, 2, 3, 4, 5, 6]
-      expect(findOrCreate(arr, (i) => i % 2 === 0, () => 42)).to.equal(2)
+      assert.strictEqual(findOrCreate(arr, (i) => i % 2 === 0, () => 42), 2)
     })
 
     it('leaves array intact on match', function () {
       const arr = [1, 2, 3, 4, 5, 6]
       findOrCreate(arr, (i) => i % 2 === 0, () => 42)
-      expect(arr).to.deep.equal([1, 2, 3, 4, 5, 6])
+      assert.deepStrictEqual(arr, [1, 2, 3, 4, 5, 6])
     })
 
     it('does not call construct on match', function (done) {
@@ -26,33 +25,33 @@ describe('util/find-or-create.ts', function () {
 
     it('matches even if match is falsy', function () {
       const arr = [1, 2, 0, 3]
-      expect(findOrCreate(arr, (i) => i === 0, () => 42)).to.equal(0)
-      expect(arr).to.deep.equal([1, 2, 0, 3])
+      assert.strictEqual(findOrCreate(arr, (i) => i === 0, () => 42), 0)
+      assert.deepStrictEqual(arr, [1, 2, 0, 3])
     })
 
     it('matches even if match is literal undefined', function () {
       const arr = [undefined]
-      expect(findOrCreate(arr, () => true, () => 42)).to.be.undefined
-      expect(arr).to.deep.equal([undefined])
+      assert.strictEqual(findOrCreate(arr, () => true, () => 42), undefined)
+      assert.deepStrictEqual(arr, [undefined])
     })
   })
 
   describe('no match', function () {
     it('returns constructed item if none match', function () {
       const arr = [1, 2, 3, 4, 5, 6]
-      expect(findOrCreate(arr, () => false, () => 42)).to.equal(42)
+      assert.strictEqual(findOrCreate(arr, () => false, () => 42), 42)
     })
 
     it('appends constructed item to array', function () {
       const arr = [1, 2, 3, 4, 5, 6]
       findOrCreate(arr, () => false, () => 42)
-      expect(arr).to.deep.equal([1, 2, 3, 4, 5, 6, 42])
+      assert.deepStrictEqual(arr, [1, 2, 3, 4, 5, 6, 42])
     })
 
     it('always constructs if array is empty', function () {
       const arr: number[] = []
-      expect(findOrCreate(arr, () => true, () => 42)).to.equal(42)
-      expect(arr).to.deep.equal([42])
+      assert.strictEqual(findOrCreate(arr, () => true, () => 42), 42)
+      assert.deepStrictEqual(arr, [42])
     })
   })
 })


### PR DESCRIPTION
Fewer dependencies! (Okay, we have to add Node.js type declarations, but
I think that's a good tradeoff.)