### PR TITLE
chore: Add a simple benchmark script

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+---
+exclude_patterns:
+  - "test/"
+  - "benchmark/"
+  - "dist/"
+  - "coverage/"

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,0 +1,95 @@
+import { faker } from '@faker-js/faker'
+import { group } from '../src/index.js'
+
+// random seed, but hardcoded to make benchmarks reproducible
+faker.seed(6676776800545831)
+
+const sampleData = {
+  numbers10k: Array.from({ length: 10_000 }, (_, i) => i),
+  numbers100k: Array.from({ length: 100_000 }, (_, i) => i),
+  objects: Array.from({ length: 10_000 }, () => ({
+    cellName: faker.music.genre(),
+    name: faker.name.fullName(),
+    test: faker.lorem.paragraph()
+  })),
+  objectKeys100: Array.from({ length: 100 }, () => ({
+    date: {
+      year: 2022,
+      month: faker.datatype.number({ min: 0, max: 11 }),
+      day: faker.datatype.number({ min: 1, max: 31 })
+    },
+    payload: faker.datatype.array(10)
+  })),
+  objectKeys1000: Array.from({ length: 1_000 }, () => ({
+    date: {
+      year: 2022,
+      month: faker.datatype.number({ min: 0, max: 11 }),
+      day: faker.datatype.number({ min: 1, max: 31 })
+    },
+    payload: faker.datatype.array(10)
+  }))
+}
+
+benchmark('remainder-10k', 1000, () => {
+  group(sampleData.numbers10k).by((num) => num % 100).asArrays()
+})
+
+benchmark('remainder-100k', 100, () => {
+  group(sampleData.numbers100k).by((num) => num % 100).asArrays()
+})
+
+benchmark('object-attribute', 1000, () => {
+  group(sampleData.objects).by('cellName').asObject()
+})
+
+benchmark('object-callback', 1000, () => {
+  group(sampleData.objects).by((obj) => obj.cellName).asObject()
+})
+
+benchmark('complex-key-100', 200, () => {
+  group(sampleData.objectKeys100).by('date').asArrays()
+})
+
+benchmark('complex-key-1000', 20, () => {
+  group(sampleData.objectKeys1000).by('date').asArrays()
+})
+
+/**
+ * Run a benchmark.
+ *
+ * @param name Name of the benchmark.
+ * @param samples Number of samples to run.
+ * @param fn Function to benchmark.
+ */
+function benchmark (name: string, samples: number, fn: () => void): void {
+  console.log(`Benchmarking ${name} (${samples} samples)`)
+  const runs = [0, 1, 2, 4, 5].map(() => computeBenchmark(name, samples, fn)).sort((a, b) => a - b)
+  // take the middle value to avoid outliers
+  const duration = runs[2]
+  const total = duration.toFixed(3)
+  const average = (duration / samples).toFixed(3)
+  const ops = (samples / (duration / 1000)).toFixed(2)
+  console.log(`total: ${total}ms, average: ${average}ms, ops/s: ${ops}`)
+  console.log()
+}
+
+/**
+ * Perform a single benchmark run, returning the duration in milliseconds.
+ *
+ * @param name Name of the benchmark.
+ * @param samples Number of samples to run.
+ * @param fn Function to benchmark.
+ * @returns Duration in milliseconds.
+ */
+function computeBenchmark (name: string, samples: number, fn: () => void): number {
+  const startMark = performance.mark(`${name}-start`)
+  for (let i = 0; i < samples; ++i) {
+    fn()
+  }
+  const endMark = performance.mark(`${name}-end`)
+  const measure = performance.measure(name, startMark.name, endMark.name)
+  performance.clearMarks(startMark.name)
+  performance.clearMarks(endMark.name)
+  performance.clearMeasures(measure.name)
+  return measure.duration
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "deep-eql": "^4.0.0"
       },
       "devDependencies": {
+        "@faker-js/faker": "7.6.0",
         "@meyfa/eslint-config": "3.0.0",
         "@types/mocha": "10.0.1",
         "@types/node": "18.15.10",
@@ -112,6 +113,16 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3734,6 +3745,12 @@
       "version": "8.36.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
       "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+      "dev": true
+    },
+    "@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore .",
     "coverage": "c8 --all --src=src --reporter=text --reporter=lcov npm test",
+    "benchmark": "ts-node benchmark/index.ts",
     "prepack": "npm run build"
   },
   "repository": {
@@ -42,6 +43,7 @@
     "npm": ">=7"
   },
   "devDependencies": {
+    "@faker-js/faker": "7.6.0",
     "@meyfa/eslint-config": "3.0.0",
     "@types/mocha": "10.0.1",
     "@types/node": "18.15.10",

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -3,6 +3,7 @@
   "include": [
     "src",
     "typings",
-    "test"
+    "test",
+    "benchmark"
   ]
 }


### PR DESCRIPTION
This patch adds a simple benchmark suite which can be run via `npm run benchmark`. It's based on PR #97 but doesn't make any attempts at setting up an automated CI workflow. Comparisons between main and any proposed changes are to be done manually (for now).