### PR TITLE
chore: Test on Node.js 22 instead of 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 21
+          - 22
           - 20
           - 18
     steps:


### PR DESCRIPTION
Node.js 21 is EOL